### PR TITLE
Feature: Add Kaigara multi-platform build CI steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 build:
 	CGO_ENABLED=0 go build -a -tags netgo -ldflags '-w' -o bin/kaigara ./cmd/kaigara
 	CGO_ENABLED=0 go build -a -ldflags '-w' -o bin/kaitail ./cmd/kaitail
-	CGO_ENABLED=0 go build -a -ldflags '-w' -o bin/kaisave ./cmd/kaisave
+	sh ./build-kaisave.sh 
 
 clean:
 	rm -rf bin/*

--- a/build-kaisave.sh
+++ b/build-kaisave.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -x
+
+platforms=("darwin/amd64" "linux/amd64" "windows/amd64")
+
+for platform in "${platforms[@]}"
+do
+    platform_split=(${platform//\// })
+    GOOS=${platform_split[0]}
+    GOARCH=${platform_split[1]}
+
+    output_os=$GOOS'_'$GOARCH
+    if [ $GOOS = "windows" ]; then
+        output_os+='.exe'
+    fi
+
+	env GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=0 go build -a -ldflags '-w' -o bin/kaisave_$output_os ./cmd/kaisave
+    if [ $? -ne 0 ]; then
+        echo 'An error has occurred! Aborting the script execution...'
+        exit 1
+    fi
+done


### PR DESCRIPTION
To make sure the Kaisave works with macOS, Linux, Windows along with the Opendax deployment stack.